### PR TITLE
Fixes the memcoin test

### DIFF
--- a/services/dkg/pedersen/controller/action.go
+++ b/services/dkg/pedersen/controller/action.go
@@ -72,13 +72,13 @@ func (a *initAction) Execute(ctx node.Context) error {
 	dela.Logger.Info().Msg("DKG has been initialized successfully")
 
 	// Place it in the map to keep it in sync
-	var dkgMap pedersen.Store
-	err = ctx.Injector.Resolve(&dkgMap)
+	var db kv.DB
+	err = ctx.Injector.Resolve(&db)
 	if err != nil {
-		return xerrors.Errorf("failed to resolve dkgMap: %v", err)
+		return xerrors.Errorf("failed to resolve db: %v", err)
 	}
 
-	err = dkgMap.Update(func(tx kv.WritableTx) error {
+	err = db.Update(func(tx kv.WritableTx) error {
 		bucket, err := tx.GetBucketOrCreate([]byte(BucketName))
 		if err != nil {
 			return err
@@ -142,13 +142,13 @@ func (a *setupAction) Execute(ctx node.Context) error {
 		Msg("DKG public key")
 
 	// Save actor data to disk after Setup
-	var dkgMap pedersen.Store
-	err = ctx.Injector.Resolve(&dkgMap)
+	var db kv.DB
+	err = ctx.Injector.Resolve(&db)
 	if err != nil {
-		return xerrors.Errorf("failed to resolve dkgMap: %v", err)
+		return xerrors.Errorf("failed to resolve db: %v", err)
 	}
 
-	err = dkgMap.Update(func(tx kv.WritableTx) error {
+	err = db.Update(func(tx kv.WritableTx) error {
 		bucket, err := tx.GetBucketOrCreate([]byte(BucketName))
 		if err != nil {
 			return err
@@ -249,13 +249,13 @@ func (a *exportInfoAction) Execute(ctx node.Context) error {
 	// Print address
 	fmt.Fprint(ctx.Out, desc)
 
-	var dkgMap pedersen.Store
-	err = ctx.Injector.Resolve(&dkgMap)
+	var db kv.DB
+	err = ctx.Injector.Resolve(&db)
 	if err != nil {
 		return xerrors.Errorf("injector: %v", err)
 	}
 
-	err = dkgMap.View(func(tx kv.ReadableTx) error {
+	err = db.View(func(tx kv.ReadableTx) error {
 		bucket := tx.GetBucket([]byte(BucketName))
 		if bucket == nil {
 			return nil

--- a/services/dkg/pedersen/controller/action_test.go
+++ b/services/dkg/pedersen/controller/action_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/dedis/d-voting/internal/testing/fake"
 	"github.com/dedis/d-voting/services/dkg"
-	"github.com/dedis/d-voting/services/dkg/pedersen"
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/dela/cli"
 	"go.dedis.ch/dela/cli/node"
@@ -41,15 +40,15 @@ func TestInitAction_Execute(t *testing.T) {
 	p := fake.Pedersen{Actors: make(map[string]dkg.Actor)}
 	ctx.Injector.Inject(p)
 	err = action.Execute(ctx)
-	require.EqualError(t, err, "failed to resolve dkgMap: couldn't find dependency for 'pedersen.Store'")
+	require.EqualError(t, err, "failed to resolve db: couldn't find dependency for 'kv.DB'")
 
 	ctx.Injector = node.NewInjector()
 
 	// Try with a DKG and a DKGMap in the system
 	p.Actors = make(map[string]dkg.Actor)
 	ctx.Injector.Inject(p)
-	dkgMap := pedersen.SimpleStore{DB: fake.NewInMemoryDB()}
-	ctx.Injector.Inject(dkgMap)
+	db := fake.NewInMemoryDB()
+	ctx.Injector.Inject(db)
 
 	err = action.Execute(ctx)
 	require.NoError(t, err)
@@ -91,12 +90,11 @@ func TestSetupAction_Execute(t *testing.T) {
 	inj.Inject(p)
 
 	err = action.Execute(ctx)
-	require.EqualError(t, err, "failed to resolve dkgMap: couldn't find dependency for 'pedersen.Store'")
+	require.EqualError(t, err, "failed to resolve db: couldn't find dependency for 'kv.DB'")
 
 	// DKG and DKGMap
 	db := fake.NewInMemoryDB()
-	dkgMap := pedersen.SimpleStore{DB: db}
-	ctx.Injector.Inject(dkgMap)
+	ctx.Injector.Inject(db)
 
 	err = action.Execute(ctx)
 	require.NoError(t, err)
@@ -139,9 +137,10 @@ func TestExportInfoAction_Execute(t *testing.T) {
 
 	ctx.Injector.Inject(fake.Mino{})
 	err = action.Execute(ctx)
-	require.EqualError(t, err, "injector: couldn't find dependency for 'pedersen.Store'")
+	require.EqualError(t, err, "injector: couldn't find dependency for 'kv.DB'")
 
-	ctx.Injector.Inject(pedersen.SimpleStore{DB: fake.NewInMemoryDB()})
+	db := fake.NewInMemoryDB()
+	ctx.Injector.Inject(db)
 	err = action.Execute(ctx)
 	require.NoError(t, err)
 

--- a/services/dkg/pedersen/controller/mod_test.go
+++ b/services/dkg/pedersen/controller/mod_test.go
@@ -69,6 +69,8 @@ func TestMinimal_OnStart(t *testing.T) {
 
 	ctx.Injector.Inject(&cosipbft.Service{})
 
+	ctx.Injector.Inject(&fake.InMemoryDB{})
+
 	// Should miss flags
 	err = c.OnStart(nil, ctx.Injector)
 	require.EqualError(t, err, "no flags")

--- a/services/dkg/pedersen/mod.go
+++ b/services/dkg/pedersen/mod.go
@@ -10,7 +10,6 @@ import (
 	"go.dedis.ch/dela"
 	"go.dedis.ch/dela/core/ordering"
 	"go.dedis.ch/dela/core/ordering/cosipbft/authority"
-	"go.dedis.ch/dela/core/store/kv"
 
 	electionTypes "github.com/dedis/d-voting/contracts/evoting/types"
 
@@ -378,23 +377,6 @@ func (a *Actor) Reshare() error {
 func (a *Actor) MarshalJSON() ([]byte, error) {
 	return a.handler.MarshalJSON()
 }
-
-// Store tags a store for Pedersen
-type Store interface {
-	kv.DB
-
-	// DKGStore is a marker to distinguish Store from kv.DB.
-	DKGStore()
-}
-
-// SimpleStore wraps a store for Pedersen
-//
-// - implements pedersen.Store
-type SimpleStore struct {
-	kv.DB
-}
-
-func (s SimpleStore) DKGStore() {}
 
 func electionExists(service ordering.Service, electionIDBuf []byte) (ordering.Proof, bool) {
 	proof, err := service.GetProof(electionIDBuf)


### PR DESCRIPTION
- DKG wasn't closing its DB (! @augustebaum )
- At the end it makes much more sense that DKG uses the Dela DB, it solves the problem of injecting multiple instances of the `kv.DB` object.
- Adapts the DKG tests consequently