### PR TITLE
rename decryptBallotsEndpoint

### DIFF
--- a/contracts/evoting/controller/action.go
+++ b/contracts/evoting/controller/action.go
@@ -721,7 +721,7 @@ func (a *scenarioTestAction) Execute(ctx node.Context) error {
 		return xerrors.Errorf("failed to set marshall types.SimpleElection : %v", err)
 	}
 
-	resp, err = http.Post(proxyAddr1+decryptBallotsEndpoint, contentType, bytes.NewBuffer(js))
+	resp, err = http.Post(proxyAddr1+combineSharesEndpoint, contentType, bytes.NewBuffer(js))
 	if err != nil {
 		return xerrors.Errorf("failed retrieve the decryption from the server: %v", err)
 	}

--- a/contracts/evoting/controller/http.go
+++ b/contracts/evoting/controller/http.go
@@ -32,7 +32,7 @@ const (
 	closeElectionEndpoint       = "/evoting/close"
 	shuffleBallotsEndpoint      = "/evoting/shuffle"
 	beginDecryptionEndpoint     = "/evoting/beginDecryption"
-	decryptBallotsEndpoint      = "/evoting/decrypt"
+	combineSharesEndpoint       = "/evoting/combineShares"
 	getElectionResultEndpoint   = "/evoting/result"
 	cancelElectionEndpoint      = "/evoting/cancel"
 )
@@ -89,7 +89,7 @@ func registerVotingProxy(proxy proxy.Proxy, signer crypto.Signer,
 	proxy.RegisterHandler(closeElectionEndpoint, h.CloseElection)
 	proxy.RegisterHandler(shuffleBallotsEndpoint, h.ShuffleBallots)
 	proxy.RegisterHandler(beginDecryptionEndpoint, h.BeginDecryption)
-	proxy.RegisterHandler(decryptBallotsEndpoint, h.CombineShares)
+	proxy.RegisterHandler(combineSharesEndpoint, h.CombineShares)
 	proxy.RegisterHandler(getElectionResultEndpoint, h.ElectionResult)
 	proxy.RegisterHandler(cancelElectionEndpoint, h.CancelElection)
 }


### PR DESCRIPTION
Rename the URL for decryption to combineShares, as it has been done everywhere else.