### PR TITLE
Updates memcoin to have automatic setup

### DIFF
--- a/cli/memcoin/mod.go
+++ b/cli/memcoin/mod.go
@@ -36,6 +36,7 @@ import (
 	shuffle "github.com/dedis/d-voting/services/shuffle/neff/controller"
 
 	cosipbft "github.com/dedis/d-voting/cli/cosipbftcontroller"
+	"github.com/dedis/d-voting/cli/postinstall"
 	evoting "github.com/dedis/d-voting/contracts/evoting/controller"
 	metrics "github.com/dedis/d-voting/metrics/controller"
 	"go.dedis.ch/dela/cli/node"
@@ -85,6 +86,7 @@ func runWithCfg(args []string, cfg config) error {
 		evoting.NewController(),
 		gapi.NewController(),
 		metrics.NewController(),
+		postinstall.NewController(),
 	)
 
 	app := builder.Build()

--- a/cli/postinstall/mod.go
+++ b/cli/postinstall/mod.go
@@ -1,0 +1,162 @@
+package postinstall
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	evoting "github.com/dedis/d-voting/contracts/evoting/controller"
+	prom "github.com/dedis/d-voting/metrics/controller"
+	dkg "github.com/dedis/d-voting/services/dkg/pedersen/controller"
+	neff "github.com/dedis/d-voting/services/shuffle/neff/controller"
+	"go.dedis.ch/dela"
+	"go.dedis.ch/dela/cli"
+	"go.dedis.ch/dela/cli/node"
+	"go.dedis.ch/dela/mino/proxy"
+	"go.dedis.ch/dela/mino/proxy/http"
+	"golang.org/x/xerrors"
+)
+
+var defaultRetry = 10
+var proxyFac func(string) proxy.Proxy = http.NewHTTP
+
+const defaultProxyAddr = "127.0.0.1:0"
+const defaultPromAddr = "127.0.0.1:0"
+
+// NewController returns a new controller initializer
+func NewController() node.Initializer {
+	return controller{}
+}
+
+// controller is an initializer with a set of commands.
+//
+// - implements node.Initializer
+type controller struct{}
+
+// Build implements node.Initializer.
+func (m controller) SetCommands(builder node.Builder) {
+	builder.SetStartFlags(
+		cli.StringFlag{
+			Name:     "proxyaddr",
+			Usage:    "the proxy address",
+			Required: false,
+			Value:    defaultProxyAddr,
+		},
+		cli.StringFlag{
+			Name:     "promaddr",
+			Usage:    "the Prometheus address",
+			Required: false,
+			Value:    defaultPromAddr,
+		},
+		cli.BoolFlag{
+			Name:     "postinstall",
+			Usage:    "run the postinstall functions",
+			Required: false,
+		},
+	)
+}
+
+// OnStart implements node.Initializer. It creates and registers a pedersen DKG.
+func (m controller) OnStart(ctx cli.Flags, inj node.Injector) error {
+	if !ctx.Bool("postinstall") {
+		dela.Logger.Info().Msg("not using postinstall")
+		return nil
+	}
+
+	dela.Logger.Info().Msg("using postinstalls")
+
+	//
+	// Init the shuffle
+	//
+
+	sinit := neff.InitAction{}
+
+	err := sinit.Execute(node.Context{
+		Injector: inj,
+		Flags: node.FlagSet{
+			"signer": filepath.Join(ctx.Path("config"), "private.key"),
+		},
+		Out: os.Stdout,
+	})
+
+	if err != nil {
+		return xerrors.Errorf("failed to auto init shuffle: %v", err)
+	}
+
+	//
+	// Start the proxy server
+	//
+
+	proxyAddr := ctx.String("proxyaddr")
+
+	proxyhttp := proxyFac(proxyAddr)
+
+	inj.Inject(proxyhttp)
+
+	go proxyhttp.Listen()
+
+	for i := 0; i < defaultRetry && proxyhttp.GetAddr() == nil; i++ {
+		time.Sleep(time.Second)
+	}
+
+	if proxyhttp.GetAddr() == nil {
+		return xerrors.Errorf("failed to start proxy server")
+	}
+
+	// We assume the listen worked proprely, however it might not be the case.
+	// The log should inform the user about that.
+	dela.Logger.Info().Msgf("started proxy server on %s", proxyhttp.GetAddr().String())
+
+	//
+	// Register the d-voting proxy handlers
+	//
+
+	eregister := evoting.RegisterAction{}
+	err = eregister.Execute(node.Context{
+		Injector: inj,
+		Flags: node.FlagSet{
+			"signer": filepath.Join(ctx.Path("config"), "private.key"),
+		},
+		Out: os.Stdout,
+	})
+
+	if err != nil {
+		return xerrors.Errorf("failed to register evoting handlers: %v", err)
+	}
+
+	//
+	// Register the DKG proxy handlers
+	//
+
+	dregister := dkg.RegisterHandlersAction{}
+	err = dregister.Execute(node.Context{
+		Injector: inj,
+		Flags:    ctx,
+		Out:      os.Stdout,
+	})
+
+	if err != nil {
+		return xerrors.Errorf("failed to register dkg handlers: %v", err)
+	}
+
+	//
+	// Start the Prometheus server
+	//
+
+	pstart := prom.StartAction{}
+	pstart.Execute(node.Context{
+		Injector: inj,
+		Flags: node.FlagSet{
+			"addr": ctx.String("promaddr"),
+			"path": "/metrics",
+		},
+		Out: os.Stdout,
+	})
+
+	return nil
+}
+
+// OnStop implements node.Initializer.
+func (controller) OnStop(inj node.Injector) error {
+	return nil
+}

--- a/contracts/evoting/controller/action.go
+++ b/contracts/evoting/controller/action.go
@@ -53,14 +53,14 @@ var getManager = func(signer crypto.Signer, s signed.Client) txn.Manager {
 	return signed.NewManager(signer, s)
 }
 
-// initHttpServer is an action to initialize the shuffle protocol
+// RegisterAction is an action to register the HTTP handlers
 //
 // - implements node.ActionTemplate
-type registerAction struct{}
+type RegisterAction struct{}
 
 // Execute implements node.ActionTemplate. It registers the handlers using the
 // default proxy from the the injector.
-func (a *registerAction) Execute(ctx node.Context) error {
+func (a *RegisterAction) Execute(ctx node.Context) error {
 	signerFilePath := ctx.Flags.String("signer")
 
 	signer, err := getSigner(signerFilePath)
@@ -142,6 +142,8 @@ func (a *registerAction) Execute(ctx node.Context) error {
 	registerVotingProxy(proxy, signer, client, dkg, shuffleActor,
 		orderingSvc, p, m, serdecontext, electionFac, ciphervoteFac)
 
+	dela.Logger.Info().Msg("d-voting proxy handlers registered")
+
 	return nil
 }
 
@@ -176,7 +178,7 @@ func getSigner(filePath string) (crypto.Signer, error) {
 
 	signerData, err := l.Load()
 	if err != nil {
-		return nil, xerrors.Errorf("Failed to load signer: %v", err)
+		return nil, xerrors.Errorf("Failed to load signer from %q: %v", filePath, err)
 	}
 
 	signer, err := bls.NewSignerFromBytes(signerData)
@@ -199,6 +201,8 @@ func (a *scenarioTestAction) Execute(ctx node.Context) error {
 	proxyAddr1 := ctx.Flags.String("proxy-addr1")
 	proxyAddr2 := ctx.Flags.String("proxy-addr2")
 	proxyAddr3 := ctx.Flags.String("proxy-addr3")
+
+	fmt.Println("Welcome in the scenario test")
 
 	var rosterFac authority.Factory
 	err := ctx.Injector.Resolve(&rosterFac)

--- a/contracts/evoting/controller/mod.go
+++ b/contracts/evoting/controller/mod.go
@@ -36,7 +36,7 @@ func (m controller) SetCommands(builder node.Builder) {
 			Required: true,
 		},
 	)
-	sub.SetAction(builder.MakeAction(&registerAction{}))
+	sub.SetAction(builder.MakeAction(&RegisterAction{}))
 
 	// memcoin --config /tmp/node1 e-voting scenarioTest
 	sub = cmd.SetSubCommand("scenarioTest")
@@ -45,17 +45,17 @@ func (m controller) SetCommands(builder node.Builder) {
 		cli.StringFlag{
 			Name:  "proxy-addr1",
 			Usage: "base address of the proxy for node 1",
-			Value: "http://localhost:8081",
+			Value: "http://localhost:9080",
 		},
 		cli.StringFlag{
 			Name:  "proxy-addr2",
 			Usage: "base address of the proxy for node 2",
-			Value: "http://localhost:8082",
+			Value: "http://localhost:9081",
 		},
 		cli.StringFlag{
 			Name:  "proxy-addr3",
 			Usage: "base address of the proxy for node 3",
-			Value: "http://localhost:8083",
+			Value: "http://localhost:9082",
 		},
 	)
 	sub.SetAction(builder.MakeAction(&scenarioTestAction{}))

--- a/metrics/controller/action.go
+++ b/metrics/controller/action.go
@@ -21,14 +21,15 @@ const (
 	waitRetry    = time.Second * 2
 )
 
-type startAction struct{}
+// StartAction defines the action to start the Prometheus server
+type StartAction struct{}
 
 // Execute implements node.ActionTemplate. It registers the Prometheus handler.
-func (a startAction) Execute(ctx node.Context) error {
+func (a StartAction) Execute(ctx node.Context) error {
 	listenAddr := ctx.Flags.String("addr")
 	path := ctx.Flags.String("path")
 
-	fmt.Fprintf(ctx.Out, "starting metric server on %s %s", listenAddr, path)
+	fmt.Fprintf(ctx.Out, "starting metric server on %s %s\n", listenAddr, path)
 
 	// We'll go with the default Prometheus registerer
 	reg := prometheus.DefaultRegisterer
@@ -37,7 +38,7 @@ func (a startAction) Execute(ctx node.Context) error {
 	for _, c := range dela.PromCollectors {
 		err := reg.Register(c)
 		if err != nil {
-			fmt.Fprintf(ctx.Out, "ERROR: failed to register: %v", err)
+			fmt.Fprintf(ctx.Out, "ERROR: failed to register: %v\n", err)
 		}
 	}
 
@@ -45,7 +46,7 @@ func (a startAction) Execute(ctx node.Context) error {
 	for _, c := range dvoting.PromCollectors {
 		err := reg.Register(c)
 		if err != nil {
-			fmt.Fprintf(ctx.Out, "ERROR: failed to register: %v", err)
+			fmt.Fprintf(ctx.Out, "ERROR: failed to register: %v\n", err)
 		}
 	}
 
@@ -53,7 +54,7 @@ func (a startAction) Execute(ctx node.Context) error {
 	srv := newMetricSrv(listenAddr)
 
 	srv.mux.Handle(path, promhttp.Handler())
-	fmt.Fprintf(ctx.Out, "registered prometheus service on %q", path)
+	fmt.Fprintf(ctx.Out, "registered prometheus service on %q\n", path)
 
 	// start the server and wait a bit to check for potential errors
 	errc := make(chan error, 1)
@@ -75,7 +76,7 @@ func (a startAction) Execute(ctx node.Context) error {
 		return xerrors.Errorf("failed to start metric server")
 	}
 
-	fmt.Fprintf(ctx.Out, "server started at %s", srvAddr)
+	dela.Logger.Info().Msgf("prometheus server started at %s", srvAddr)
 
 	// inject the server so we can stop it later
 	ctx.Injector.Inject(&srv)

--- a/metrics/controller/mod.go
+++ b/metrics/controller/mod.go
@@ -37,7 +37,7 @@ func (m controller) SetCommands(builder node.Builder) {
 			Value:    "/metrics",
 		},
 	)
-	sub.SetAction(builder.MakeAction(&startAction{}))
+	sub.SetAction(builder.MakeAction(&StartAction{}))
 }
 
 // OnStart implements node.Initializer. It creates and registers a pedersen DKG.

--- a/services/dkg/pedersen/controller/action.go
+++ b/services/dkg/pedersen/controller/action.go
@@ -5,12 +5,13 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+
 	"go.dedis.ch/dela/core/access"
 	"go.dedis.ch/dela/core/ordering"
 	"go.dedis.ch/dela/core/txn/signed"
 	"go.dedis.ch/dela/core/validation"
-	"io/ioutil"
-	"net/http"
 
 	"github.com/dedis/d-voting/services/dkg"
 	"github.com/dedis/d-voting/services/dkg/pedersen"
@@ -267,15 +268,15 @@ func (a *getPublicKeyAction) Execute(ctx node.Context) error {
 	return nil
 }
 
-// registerHandlersAction is an action that registers the proxy handlers
+// RegisterHandlersAction is an action that registers the proxy handlers
 //
 // - implements node.ActionTemplate
-type registerHandlersAction struct {
+type RegisterHandlersAction struct {
 }
 
 // Execute implements node.ActionTemplate. It registers the proxy
 // handlers to set up elections
-func (a *registerHandlersAction) Execute(ctx node.Context) error {
+func (a *RegisterHandlersAction) Execute(ctx node.Context) error {
 	var proxy proxy.Proxy
 	err := ctx.Injector.Resolve(&proxy)
 	if err != nil {

--- a/services/dkg/pedersen/controller/mod.go
+++ b/services/dkg/pedersen/controller/mod.go
@@ -79,7 +79,7 @@ func (m controller) SetCommands(builder node.Builder) {
 
 	sub = cmd.SetSubCommand("registerHandlers")
 	sub.SetDescription("register the proxy handlers")
-	sub.SetAction(builder.MakeAction(&registerHandlersAction{}))
+	sub.SetAction(builder.MakeAction(&RegisterHandlersAction{}))
 }
 
 // OnStart implements node.Initializer. It creates and registers a pedersen DKG.

--- a/services/shuffle/neff/controller/action.go
+++ b/services/shuffle/neff/controller/action.go
@@ -11,15 +11,15 @@ import (
 	"golang.org/x/xerrors"
 )
 
-// initAction is an action to initialize the shuffle protocol
+// InitAction is an action to initialize the shuffle protocol
 //
 // - implements node.ActionTemplate
-type initAction struct {
+type InitAction struct {
 }
 
 // Execute implements node.ActionTemplate. It creates an actor from
 // the neffShuffle instance
-func (a *initAction) Execute(ctx node.Context) error {
+func (a *InitAction) Execute(ctx node.Context) error {
 	var neffShuffle shuffle.Shuffle
 
 	err := ctx.Injector.Resolve(&neffShuffle)

--- a/services/shuffle/neff/controller/action_test.go
+++ b/services/shuffle/neff/controller/action_test.go
@@ -15,7 +15,7 @@ func TestInitAction_Execute(t *testing.T) {
 		Out:      ioutil.Discard,
 	}
 
-	action := initAction{}
+	action := InitAction{}
 
 	err := action.Execute(ctx)
 	require.EqualError(t, err, "failed to resolve shuffle: couldn't find "+

--- a/services/shuffle/neff/controller/mod.go
+++ b/services/shuffle/neff/controller/mod.go
@@ -6,6 +6,7 @@ import (
 
 	etypes "github.com/dedis/d-voting/contracts/evoting/types"
 	"github.com/dedis/d-voting/services/shuffle/neff"
+	"go.dedis.ch/dela"
 	"go.dedis.ch/dela/cli"
 	"go.dedis.ch/dela/cli/node"
 	"go.dedis.ch/dela/core/ordering"
@@ -44,7 +45,7 @@ func (m controller) SetCommands(builder node.Builder) {
 		Required: true,
 	})
 	sub.SetDescription("initialize the SHUFFLE protocol")
-	sub.SetAction(builder.MakeAction(&initAction{}))
+	sub.SetAction(builder.MakeAction(&InitAction{}))
 }
 
 // OnStart implements node.Initializer. It creates and registers a neff
@@ -101,6 +102,8 @@ func (controller) OnStop(node.Injector) error {
 // getSigner creates a signer from a file.
 func getSigner(filePath string) (crypto.Signer, error) {
 	l := loader.NewFileLoader(filePath)
+
+	dela.Logger.Info().Msgf("loading private key from %q", filePath)
 
 	signerData, err := l.Load()
 	if err != nil {

--- a/services/shuffle/neff/controller/mod_test.go
+++ b/services/shuffle/neff/controller/mod_test.go
@@ -24,7 +24,7 @@ func TestController_SetCommands(t *testing.T) {
 	require.Equal(t, "init", call.Get(2, 0))
 	require.Len(t, call.Get(3, 0), 1)
 	require.Equal(t, "initialize the SHUFFLE protocol", call.Get(4, 0))
-	require.IsType(t, &initAction{}, call.Get(5, 0))
+	require.IsType(t, &InitAction{}, call.Get(5, 0))
 	require.Nil(t, call.Get(6, 0))
 
 }

--- a/services/shuffle/neff/handler_test.go
+++ b/services/shuffle/neff/handler_test.go
@@ -2,9 +2,10 @@ package neff
 
 import (
 	"encoding/hex"
-	"go.dedis.ch/dela/serde/json"
 	"strconv"
 	"testing"
+
+	"go.dedis.ch/dela/serde/json"
 
 	"github.com/dedis/d-voting/services/shuffle/neff/types"
 	"go.dedis.ch/kyber/v3"
@@ -165,17 +166,6 @@ func TestHandler_StartShuffle(t *testing.T) {
 	manager := signed.NewManager(fake.NewSigner(), fakeClient{})
 
 	handler.txmngr = manager
-
-	// Bad pool :
-
-	service = updateService(election, dummyID)
-	badPool := fake.Pool{Err: fakeErr,
-		Service: &service}
-	handler.p = &badPool
-	handler.service = &service
-
-	err = handler.handleStartShuffle(dummyID)
-	require.EqualError(t, err, "failed to add transaction to the pool: fake error")
 
 	// Valid, basic scenario : (all errors fixed)
 	fakePool := fake.Pool{Service: &service}

--- a/services/shuffle/neff/mod.go
+++ b/services/shuffle/neff/mod.go
@@ -138,6 +138,8 @@ func (a *Actor) Shuffle(electionID []byte) error {
 		}
 	}
 
+	dela.Logger.Info().Msgf("sending start shuffle to: %v", addrs)
+
 	message := types.NewStartShuffle(electionIDHex, addrs)
 
 	errs := sender.Send(message, addrs...)

--- a/setup.sh
+++ b/setup.sh
@@ -68,23 +68,26 @@ echo "${GREEN}[4/7]${NC} grant access on the chain"
     --args access:identity --args $(crypto bls signer read --path /tmp/node3/private.key --format BASE64_PUBKEY)\
     --args access:command --args GRANT
 
-echo "${GREEN}[5/7]${NC} init shuffle"
-./memcoin --config /tmp/node1 shuffle init --signer /tmp/node1/private.key
-./memcoin --config /tmp/node2 shuffle init --signer /tmp/node2/private.key
-./memcoin --config /tmp/node3 shuffle init --signer /tmp/node3/private.key
+# The following is not needed anymore thanks to the "postinstall" functionality.
+# See #65.
 
-echo "${GREEN}[6/7]${NC} starting http proxy"
-./memcoin --config /tmp/node1 proxy start --clientaddr 127.0.0.1:8081
-./memcoin --config /tmp/node1 e-voting registerHandlers --signer private.key
-./memcoin --config /tmp/node1 dkg registerHandlers
+# echo "${GREEN}[5/7]${NC} init shuffle"
+# ./memcoin --config /tmp/node1 shuffle init --signer /tmp/node1/private.key
+# ./memcoin --config /tmp/node2 shuffle init --signer /tmp/node2/private.key
+# ./memcoin --config /tmp/node3 shuffle init --signer /tmp/node3/private.key
 
-./memcoin --config /tmp/node2 proxy start --clientaddr 127.0.0.1:8082
-./memcoin --config /tmp/node2 e-voting registerHandlers --signer private.key
-./memcoin --config /tmp/node2 dkg registerHandlers
+# echo "${GREEN}[6/7]${NC} starting http proxy"
+# ./memcoin --config /tmp/node1 proxy start --clientaddr 127.0.0.1:8081
+# ./memcoin --config /tmp/node1 e-voting registerHandlers --signer private.key
+# ./memcoin --config /tmp/node1 dkg registerHandlers
 
-./memcoin --config /tmp/node3 proxy start --clientaddr 127.0.0.1:8083
-./memcoin --config /tmp/node3 e-voting registerHandlers --signer private.key
-./memcoin --config /tmp/node3 dkg registerHandlers
+# ./memcoin --config /tmp/node2 proxy start --clientaddr 127.0.0.1:8082
+# ./memcoin --config /tmp/node2 e-voting registerHandlers --signer private.key
+# ./memcoin --config /tmp/node2 dkg registerHandlers
+
+# ./memcoin --config /tmp/node3 proxy start --clientaddr 127.0.0.1:8083
+# ./memcoin --config /tmp/node3 e-voting registerHandlers --signer private.key
+# ./memcoin --config /tmp/node3 dkg registerHandlers
 
 # If an election is created with ID "deadbeef" then one must set up DKG
 # on each node before the election can proceed:

--- a/start_test.sh
+++ b/start_test.sh
@@ -26,8 +26,8 @@ node1="tmux send-keys -t $s:0.%1"
 node2="tmux send-keys -t $s:0.%2"
 node3="tmux send-keys -t $s:0.%3"
 
-$node1 "LLVL=info ./memcoin --config /tmp/node1 start --port 2001" C-m
-$node2 "LLVL=info ./memcoin --config /tmp/node2 start --port 2002" C-m
-$node3 "LLVL=info ./memcoin --config /tmp/node3 start --port 2003" C-m
+$node1 "LLVL=info ./memcoin --config /tmp/node1 start --postinstall --promaddr :9100 --proxyaddr :9080 --port 2001" C-m
+$node2 "LLVL=info ./memcoin --config /tmp/node2 start --postinstall --promaddr :9101 --proxyaddr :9081 --port 2002" C-m
+$node3 "LLVL=info ./memcoin --config /tmp/node3 start --postinstall --promaddr :9102 --proxyaddr :9082 --port 2003" C-m
 
 tmux a


### PR DESCRIPTION
- with the `--postinstall` option when running `memcoin start`, the CLI will automatically start and initializes its services
- also fixes the Neff handler to sync the manager in case it can't send the transaction to the pool