### PR TITLE
Implements signed requests on the proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,16 @@ go build ./cli/memcoin
 In three different terminal sessions, from the root folder:
 
 ```sh
-LLVL=info memcoin --config /tmp/node1 start --port 2001
+pk=adbacd10fdb9822c71025d6d00092b8a4abb5ebcb673d28d863f7c7c5adaddf3
 
-LLVL=info memcoin --config /tmp/node2 start --port 2002
+LLVL=info memcoin --config /tmp/node1 start --postinstall \
+  --promaddr :9100 --proxyaddr :9080 --proxykey $pk --port 2001
 
-LLVL=info memcoin --config /tmp/node3 start --port 2003
+LLVL=info memcoin --config /tmp/node2 start --postinstall \
+  --promaddr :9101 --proxyaddr :9082 --proxykey $pk --port 2002
+
+LLVL=info memcoin --config /tmp/node3 start --postinstall \
+  --promaddr :9102 --proxyaddr :9083 --proxykey $pk --port 2003
 ```
 
 Then you should be able to run the setup script:

--- a/README.md
+++ b/README.md
@@ -158,8 +158,15 @@ If nodes are running and `setup.sh` has been called, you can run a test
 scenario:
 
 ```sh
-LLVL=info memcoin --config /tmp/node1 e-voting scenarioTest
+sk=28912721dfd507e198b31602fb67824856eb5a674c021d49fdccbe52f0234409
+LLVL=info memcoin --config /tmp/node1 e-voting scenarioTest --secretkey $sk
 ```
+
+For reference, here is a hex-encoded kyber Ed25519 keypair:
+
+Public key: `adbacd10fdb9822c71025d6d00092b8a4abb5ebcb673d28d863f7c7c5adaddf3`
+
+Secret key: `28912721dfd507e198b31602fb67824856eb5a674c021d49fdccbe52f0234409`
 
 # Use the frontend
 

--- a/cli/postinstall/mod.go
+++ b/cli/postinstall/mod.go
@@ -53,6 +53,11 @@ func (m controller) SetCommands(builder node.Builder) {
 			Usage:    "run the postinstall functions",
 			Required: false,
 		},
+		cli.StringFlag{
+			Name:     "proxykey",
+			Usage:    "the frontend public key that signs requests, hex encoded",
+			Required: false,
+		},
 	)
 }
 
@@ -115,7 +120,8 @@ func (m controller) OnStart(ctx cli.Flags, inj node.Injector) error {
 	err = eregister.Execute(node.Context{
 		Injector: inj,
 		Flags: node.FlagSet{
-			"signer": filepath.Join(ctx.Path("config"), "private.key"),
+			"signer":   filepath.Join(ctx.Path("config"), "private.key"),
+			"proxykey": ctx.String("proxykey"),
 		},
 		Out: os.Stdout,
 	})

--- a/contracts/evoting/controller/action.go
+++ b/contracts/evoting/controller/action.go
@@ -23,7 +23,6 @@ import (
 	eproxy "github.com/dedis/d-voting/proxy"
 	ptypes "github.com/dedis/d-voting/proxy/types"
 	"github.com/dedis/d-voting/services/dkg"
-	stypes "github.com/dedis/d-voting/services/dkg/pedersen/types"
 	"github.com/dedis/d-voting/services/shuffle"
 	"github.com/gorilla/mux"
 	"go.dedis.ch/dela"
@@ -503,9 +502,11 @@ func (a *scenarioTestAction) Execute(ctx node.Context) error {
 
 	fmt.Fprintln(ctx.Out, "shuffle ballots")
 
-	dummy := map[string]interface{}{}
+	shuffleRequest := ptypes.UpdateShuffle{
+		Action: "shuffle",
+	}
 
-	signed, err = createSignedRequest(secret, dummy)
+	signed, err = createSignedRequest(secret, shuffleRequest)
 	if err != nil {
 		return createSignedErr(err)
 	}
@@ -748,7 +749,7 @@ func initDKG(secret kyber.Scalar, proxyAddr, electionIDHex string) error {
 }
 
 func updateDKG(secret kyber.Scalar, proxyAddr, electionIDHex, action string) (int, error) {
-	msg := stypes.UpdateDKG{
+	msg := ptypes.UpdateDKG{
 		Action: action,
 	}
 

--- a/contracts/evoting/controller/action.go
+++ b/contracts/evoting/controller/action.go
@@ -160,8 +160,10 @@ func (a *RegisterAction) Execute(ctx node.Context) error {
 
 	router.HandleFunc("/evoting/elections", ep.NewElection).Methods("POST")
 	router.HandleFunc("/evoting/elections", ep.Elections).Methods("GET")
+	router.HandleFunc("/evoting/elections", eproxy.AllowCORS).Methods("OPTIONS")
 	router.HandleFunc("/evoting/elections/{electionID}", ep.Election).Methods("GET")
 	router.HandleFunc("/evoting/elections/{electionID}", ep.EditElection).Methods("PUT")
+	router.HandleFunc("/evoting/elections/{electionID}", eproxy.AllowCORS).Methods("OPTIONS")
 	router.HandleFunc("/evoting/elections/{electionID}/vote", ep.NewElectionVote).Methods("POST")
 
 	router.NotFoundHandler = http.HandlerFunc(eproxy.NotFoundHandler)

--- a/contracts/evoting/controller/mod.go
+++ b/contracts/evoting/controller/mod.go
@@ -43,6 +43,11 @@ func (m controller) SetCommands(builder node.Builder) {
 	sub.SetDescription("evoting scenario test")
 	sub.SetFlags(
 		cli.StringFlag{
+			Name:     "secretkey",
+			Usage:    "the proxy secret key to sign requests, hex encoded",
+			Required: true,
+		},
+		cli.StringFlag{
 			Name:  "proxy-addr1",
 			Usage: "base address of the proxy for node 1",
 			Value: "http://localhost:9080",

--- a/proxy/dkg.go
+++ b/proxy/dkg.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
-	ptypes "github.com/dedis/d-voting/proxy/types"
+	"github.com/dedis/d-voting/proxy/types"
 	dkgSrv "github.com/dedis/d-voting/services/dkg"
-	"github.com/dedis/d-voting/services/dkg/pedersen/types"
 	"github.com/gorilla/mux"
 	"go.dedis.ch/dela/core/txn"
 	"go.dedis.ch/kyber/v3"
@@ -33,9 +32,9 @@ type dkg struct {
 
 // NewDKGActor implements proxy.DKG
 func (d dkg) NewDKGActor(w http.ResponseWriter, r *http.Request) {
-	var req ptypes.NewDKGRequest
+	var req types.NewDKGRequest
 
-	signed, err := ptypes.NewSignedRequest(r.Body)
+	signed, err := types.NewSignedRequest(r.Body)
 	if err != nil {
 		InternalError(w, r, newSignedErr(err), nil)
 		return
@@ -87,7 +86,7 @@ func (d dkg) EditDKGActor(w http.ResponseWriter, r *http.Request) {
 
 	var req types.UpdateDKG
 
-	signed, err := ptypes.NewSignedRequest(r.Body)
+	signed, err := types.NewSignedRequest(r.Body)
 	if err != nil {
 		InternalError(w, r, newSignedErr(err), nil)
 		return

--- a/proxy/election.go
+++ b/proxy/election.go
@@ -466,7 +466,9 @@ func (h *election) getElectionsMetadata() (types.ElectionsMetadata, error) {
 
 	proof, err := h.orderingSvc.GetProof([]byte(evoting.ElectionsMetadataKey))
 	if err != nil {
-		return md, xerrors.Errorf("failed to read on the blockchain: %v", err)
+		// if the proof doesn't exist we assume there is no metadata, thus no
+		// elections has been created so far.
+		return md, nil
 	}
 
 	err = json.Unmarshal(proof.GetValue(), &md)

--- a/proxy/election.go
+++ b/proxy/election.go
@@ -407,10 +407,14 @@ func (h *election) Elections(w http.ResponseWriter, r *http.Request) {
 				http.StatusInternalServerError)
 		}
 
-		pubkeyBuf, err := election.Pubkey.MarshalBinary()
-		if err != nil {
-			http.Error(w, "failed to marshal pubkey: "+err.Error(),
-				http.StatusInternalServerError)
+		var pubkeyBuf []byte
+
+		if election.Pubkey != nil {
+			pubkeyBuf, err = election.Pubkey.MarshalBinary()
+			if err != nil {
+				http.Error(w, "failed to marshal pubkey: "+err.Error(),
+					http.StatusInternalServerError)
+			}
 		}
 
 		info := ptypes.LightElection{

--- a/proxy/election.go
+++ b/proxy/election.go
@@ -21,12 +21,21 @@ import (
 	"go.dedis.ch/dela/core/txn"
 	"go.dedis.ch/dela/core/txn/pool"
 	"go.dedis.ch/dela/serde"
+	"go.dedis.ch/kyber/v3"
 	"golang.org/x/xerrors"
 )
 
+func newSignedErr(err error) error {
+	return xerrors.Errorf("failed to created signed request: %v", err)
+}
+
+func getSignedErr(err error) error {
+	return xerrors.Errorf("failed to get and verify signed request: %v", err)
+}
+
 // NewElection returns a new initialized election proxy
 func NewElection(srv ordering.Service, mngr txn.Manager, p pool.Pool,
-	ctx serde.Context, fac serde.Factory) Election {
+	ctx serde.Context, fac serde.Factory, pk kyber.Point) Election {
 
 	logger := dela.Logger.With().Timestamp().Str("role", "evoting-proxy").Logger()
 
@@ -37,6 +46,7 @@ func NewElection(srv ordering.Service, mngr txn.Manager, p pool.Pool,
 		electionFac: fac,
 		mngr:        mngr,
 		pool:        p,
+		pk:          pk,
 	}
 }
 
@@ -52,16 +62,22 @@ type election struct {
 	electionFac serde.Factory
 	mngr        txn.Manager
 	pool        pool.Pool
+	pk          kyber.Point
 }
 
 // NewElection implements proxy.Proxy
 func (h *election) NewElection(w http.ResponseWriter, r *http.Request) {
 	var req ptypes.CreateElectionRequest
 
-	err := json.NewDecoder(r.Body).Decode(&req)
+	signed, err := ptypes.NewSignedRequest(r.Body)
 	if err != nil {
-		http.Error(w, "failed to decode CreateElectionRequest: "+err.Error(),
-			http.StatusBadRequest)
+		InternalError(w, r, newSignedErr(err), nil)
+		return
+	}
+
+	err = signed.GetAndVerify(h.pk, &req)
+	if err != nil {
+		InternalError(w, r, getSignedErr(err), nil)
 		return
 	}
 
@@ -113,10 +129,15 @@ func (h *election) NewElectionVote(w http.ResponseWriter, r *http.Request) {
 
 	var req ptypes.CastVoteRequest
 
-	err := json.NewDecoder(r.Body).Decode(&req)
+	signed, err := ptypes.NewSignedRequest(r.Body)
 	if err != nil {
-		http.Error(w, "failed to decode CastVoteRequest: "+err.Error(),
-			http.StatusBadRequest)
+		InternalError(w, r, newSignedErr(err), nil)
+		return
+	}
+
+	err = signed.GetAndVerify(h.pk, &req)
+	if err != nil {
+		InternalError(w, r, getSignedErr(err), nil)
 		return
 	}
 
@@ -200,10 +221,15 @@ func (h *election) EditElection(w http.ResponseWriter, r *http.Request) {
 
 	var req ptypes.UpdateElectionRequest
 
-	err = json.NewDecoder(r.Body).Decode(&req)
+	signed, err := ptypes.NewSignedRequest(r.Body)
 	if err != nil {
-		http.Error(w, "failed to decode UpdateElectionRequest: "+err.Error(),
-			http.StatusBadRequest)
+		InternalError(w, r, newSignedErr(err), nil)
+		return
+	}
+
+	err = signed.GetAndVerify(h.pk, &req)
+	if err != nil {
+		InternalError(w, r, getSignedErr(err), nil)
 		return
 	}
 
@@ -315,7 +341,8 @@ func (h *election) cancelElection(electionIDHex string, w http.ResponseWriter, r
 	}
 }
 
-// Election implements proxy.Proxy
+// Election implements proxy.Proxy. The request should not be signed because it
+// is fetching public data.
 func (h *election) Election(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 
@@ -361,7 +388,8 @@ func (h *election) Election(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// Elections implements proxy.Proxy
+// Elections implements proxy.Proxy. The request should not be signed because it
+// is fecthing public data.
 func (h *election) Elections(w http.ResponseWriter, r *http.Request) {
 
 	elecMD, err := h.getElectionsMetadata()

--- a/proxy/election.go
+++ b/proxy/election.go
@@ -399,7 +399,7 @@ func (h *election) Elections(w http.ResponseWriter, r *http.Request) {
 
 	elecMD, err := h.getElectionsMetadata()
 	if err != nil {
-		http.Error(w, "failed to get election metadata", http.StatusNotFound)
+		InternalError(w, r, xerrors.Errorf("failed to get election metadata: %v", err), nil)
 		return
 	}
 
@@ -408,8 +408,8 @@ func (h *election) Elections(w http.ResponseWriter, r *http.Request) {
 	for i, id := range elecMD.ElectionsIDs {
 		election, err := getElection(h.context, h.electionFac, id, h.orderingSvc)
 		if err != nil {
-			http.Error(w, xerrors.Errorf("failed to get election: %v", err).Error(),
-				http.StatusInternalServerError)
+			InternalError(w, r, xerrors.Errorf("failed to get election: %v", err), nil)
+			return
 		}
 
 		var pubkeyBuf []byte
@@ -417,8 +417,8 @@ func (h *election) Elections(w http.ResponseWriter, r *http.Request) {
 		if election.Pubkey != nil {
 			pubkeyBuf, err = election.Pubkey.MarshalBinary()
 			if err != nil {
-				http.Error(w, "failed to marshal pubkey: "+err.Error(),
-					http.StatusInternalServerError)
+				InternalError(w, r, xerrors.Errorf("failed to marshal pubkey: %v", err), nil)
+				return
 			}
 		}
 
@@ -437,8 +437,7 @@ func (h *election) Elections(w http.ResponseWriter, r *http.Request) {
 
 	err = json.NewEncoder(w).Encode(response)
 	if err != nil {
-		http.Error(w, "failed to write in ResponseWriter: "+err.Error(),
-			http.StatusInternalServerError)
+		InternalError(w, r, xerrors.Errorf("failed to write response: %v", err), nil)
 		return
 	}
 }

--- a/proxy/election.go
+++ b/proxy/election.go
@@ -424,6 +424,7 @@ func (h *election) Elections(w http.ResponseWriter, r *http.Request) {
 
 		info := ptypes.LightElection{
 			ElectionID: string(election.ElectionID),
+			Title:      election.Configuration.MainTitle,
 			Status:     uint16(election.Status),
 			Pubkey:     hex.EncodeToString(pubkeyBuf),
 		}

--- a/proxy/election.go
+++ b/proxy/election.go
@@ -344,6 +344,9 @@ func (h *election) cancelElection(electionIDHex string, w http.ResponseWriter, r
 // Election implements proxy.Proxy. The request should not be signed because it
 // is fetching public data.
 func (h *election) Election(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Headers", "*")
+
 	vars := mux.Vars(r)
 
 	if vars == nil || vars["electionID"] == "" {
@@ -391,6 +394,8 @@ func (h *election) Election(w http.ResponseWriter, r *http.Request) {
 // Elections implements proxy.Proxy. The request should not be signed because it
 // is fecthing public data.
 func (h *election) Elections(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Headers", "*")
 
 	elecMD, err := h.getElectionsMetadata()
 	if err != nil {
@@ -429,6 +434,7 @@ func (h *election) Elections(w http.ResponseWriter, r *http.Request) {
 	response := ptypes.GetElectionsResponse{Elections: allElectionsInfo}
 
 	w.Header().Set("Content-Type", "application/json")
+
 	err = json.NewEncoder(w).Encode(response)
 	if err != nil {
 		http.Error(w, "failed to write in ResponseWriter: "+err.Error(),

--- a/proxy/mod.go
+++ b/proxy/mod.go
@@ -112,3 +112,10 @@ func InternalError(w http.ResponseWriter, r *http.Request, err error, args map[s
 	w.WriteHeader(http.StatusInternalServerError)
 	fmt.Fprintln(w, string(buf))
 }
+
+// AllowCORS defines a basic handler that adds wide Access Control Allow origin
+// headers.
+func AllowCORS(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Headers", "*")
+}

--- a/proxy/mod.go
+++ b/proxy/mod.go
@@ -87,3 +87,28 @@ func NotAllowedHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusMethodNotAllowed)
 	fmt.Fprintln(w, string(buf))
 }
+
+// InternalError set an internal server error
+func InternalError(w http.ResponseWriter, r *http.Request, err error, args map[string]interface{}) {
+	if args == nil {
+		args = make(map[string]interface{})
+	}
+
+	args["error"] = err.Error()
+	args["url"] = r.URL.String()
+	args["method"] = r.Method
+
+	errMsg := types.HTTPError{
+		Title:   "Internal server error",
+		Code:    http.StatusInternalServerError,
+		Message: "A problem occurred on the proxy",
+		Args:    args,
+	}
+
+	buf, _ := json.MarshalIndent(&errMsg, "", "  ")
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(http.StatusInternalServerError)
+	fmt.Fprintln(w, string(buf))
+}

--- a/proxy/shuffle.go
+++ b/proxy/shuffle.go
@@ -5,14 +5,18 @@ import (
 	"fmt"
 	"net/http"
 
+	ptypes "github.com/dedis/d-voting/proxy/types"
 	shuffleSrv "github.com/dedis/d-voting/services/shuffle"
 	"github.com/gorilla/mux"
+	"go.dedis.ch/kyber/v3"
+	"golang.org/x/xerrors"
 )
 
 // NewShuffle returns a new initialized shuffle
-func NewShuffle(actor shuffleSrv.Actor) Shuffle {
+func NewShuffle(actor shuffleSrv.Actor, pk kyber.Point) Shuffle {
 	return shuffle{
 		actor: actor,
+		pk:    pk,
 	}
 }
 
@@ -21,6 +25,7 @@ func NewShuffle(actor shuffleSrv.Actor) Shuffle {
 // - implements proxy.Shuffle
 type shuffle struct {
 	actor shuffleSrv.Actor
+	pk    kyber.Point
 }
 
 // EditShuffle implements proxy.Shuffle
@@ -37,6 +42,18 @@ func (s shuffle) EditShuffle(w http.ResponseWriter, r *http.Request) {
 	buff, err := hex.DecodeString(electionID)
 	if err != nil {
 		http.Error(w, "failed to decode electionID: "+electionID, http.StatusInternalServerError)
+		return
+	}
+
+	signed, err := ptypes.NewSignedRequest(r.Body)
+	if err != nil {
+		InternalError(w, r, newSignedErr(err), nil)
+		return
+	}
+
+	err = signed.Verify(s.pk)
+	if err != nil {
+		InternalError(w, r, xerrors.Errorf("failed to verify signed: %v", err), nil)
 		return
 	}
 

--- a/proxy/types/dkg.go
+++ b/proxy/types/dkg.go
@@ -1,0 +1,6 @@
+package types
+
+// NewDKGRequest defines the request to create a new DGK
+type NewDKGRequest struct {
+	ElectionID string // hex-encoded
+}

--- a/proxy/types/dkg.go
+++ b/proxy/types/dkg.go
@@ -4,3 +4,8 @@ package types
 type NewDKGRequest struct {
 	ElectionID string // hex-encoded
 }
+
+// UpdateDKG defines the input used to update dkg
+type UpdateDKG struct {
+	Action string
+}

--- a/proxy/types/shuffle.go
+++ b/proxy/types/shuffle.go
@@ -1,0 +1,6 @@
+package types
+
+// UpdateShuffle defines the input used to update the shuffle
+type UpdateShuffle struct {
+	Action string
+}

--- a/proxy/types/signed.go
+++ b/proxy/types/signed.go
@@ -1,0 +1,92 @@
+package types
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+
+	"go.dedis.ch/kyber/v3"
+	"go.dedis.ch/kyber/v3/sign/schnorr"
+	"go.dedis.ch/kyber/v3/suites"
+	"golang.org/x/xerrors"
+)
+
+var suite = suites.MustFind("ed25519")
+
+// NewSignedRequest returns a new initialized signed request
+func NewSignedRequest(r io.Reader) (SignedRequest, error) {
+	var req SignedRequest
+	decoder := json.NewDecoder(r)
+
+	err := decoder.Decode(&req)
+	if err != nil {
+		return req, xerrors.Errorf("failed to decode signed request: %v", err)
+	}
+
+	return req, nil
+}
+
+// SignedRequest represents a frontend request signed by the web backend.
+type SignedRequest struct {
+	Payload   string // url base64 encoded json message
+	Signature string // hex encoded signature on sha256(Payload)
+}
+
+// GetMessage JSON unmarshals the payload to the given element. The given
+// element MUST be a pointer.
+func (s SignedRequest) GetMessage(el interface{}) error {
+	buf, err := base64.URLEncoding.DecodeString(s.Payload)
+	if err != nil {
+		return xerrors.Errorf("failed to decode base64: %v", err)
+	}
+
+	err = json.Unmarshal(buf, el)
+	if err != nil {
+		return xerrors.Errorf("failed to unmarshal json %q to %T: %v", buf, el, err)
+	}
+
+	return nil
+}
+
+// Verify checks the signature. The signature should be on the sha256 of the
+// payload.
+func (s SignedRequest) Verify(pk kyber.Point) error {
+	if len(s.Payload) == 0 {
+		return xerrors.Errorf("cannot verify empty payload")
+	}
+
+	hash := sha256.New()
+
+	hash.Write([]byte(s.Payload))
+	md := hash.Sum(nil)
+
+	sig, err := hex.DecodeString(s.Signature)
+	if err != nil {
+		return xerrors.Errorf("failed to decode signature: %v", err)
+	}
+
+	err = schnorr.Verify(suite, pk, md, sig)
+	if err != nil {
+		return xerrors.Errorf("invalid signature: %v", err)
+	}
+
+	return nil
+}
+
+// GetAndVerify is a shorthand function to verify the signed request and extract
+// the payload. el MUST be a pointer.
+func (s SignedRequest) GetAndVerify(pk kyber.Point, el interface{}) error {
+	err := s.Verify(pk)
+	if err != nil {
+		return xerrors.Errorf("failed to verify: %v", err)
+	}
+
+	err = s.GetMessage(el)
+	if err != nil {
+		return xerrors.Errorf("failed to get message: %v", err)
+	}
+
+	return nil
+}

--- a/proxy/types/signed_test.go
+++ b/proxy/types/signed_test.go
@@ -1,0 +1,219 @@
+package types
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.dedis.ch/kyber/v3/sign/schnorr"
+)
+
+func TestNewSignedRequest_bad_json(t *testing.T) {
+	data := []byte("{invalid json}")
+	r := bytes.NewReader(data)
+
+	_, err := NewSignedRequest(r)
+	require.EqualError(t, err, "failed to decode signed request: invalid "+
+		"character 'i' looking for beginning of object key string")
+}
+
+func TestNewSigedRequest_ok(t *testing.T) {
+	data := []byte(`{"Payload": "xx", "Signature": "aef123"}`)
+	r := bytes.NewReader(data)
+
+	req, err := NewSignedRequest(r)
+	require.NoError(t, err)
+
+	expected := SignedRequest{
+		Payload:   "xx",
+		Signature: "aef123",
+	}
+
+	require.Equal(t, expected, req)
+}
+
+func TestGetMessage_not_base64(t *testing.T) {
+	signed := SignedRequest{
+		Payload: "not base 64",
+	}
+
+	var req map[string]interface{}
+
+	err := signed.GetMessage(&req)
+	require.EqualError(t, err, "failed to decode base64: illegal base64 data at input byte 3")
+}
+
+func TestGetMessage_bad_req(t *testing.T) {
+	msg := `{invalid json}`
+	payload := base64.URLEncoding.EncodeToString([]byte(msg))
+
+	signed := SignedRequest{
+		Payload: payload,
+	}
+
+	var req map[string]interface{}
+
+	err := signed.GetMessage(&req)
+	require.EqualError(t, err, "failed to unmarshal json \"{invalid json}\" "+
+		"to *map[string]interface {}: invalid character 'i' looking for "+
+		"beginning of object key string")
+}
+
+func TestGetMessage_ok(t *testing.T) {
+	msg := `{"Foo": "bar"}`
+	payload := base64.URLEncoding.EncodeToString([]byte(msg))
+
+	signed := SignedRequest{
+		Payload: payload,
+	}
+
+	type dummy struct {
+		Foo string
+	}
+
+	var req dummy
+
+	err := signed.GetMessage(&req)
+	require.NoError(t, err)
+
+	expected := dummy{
+		Foo: "bar",
+	}
+
+	require.Equal(t, expected, req)
+}
+
+func TestVerify_bad_signature_hex(t *testing.T) {
+	pk := suite.Point()
+
+	signed := SignedRequest{
+		Payload:   "yy",
+		Signature: "xx",
+	}
+
+	err := signed.Verify(pk)
+	require.EqualError(t, err, "failed to decode signature: encoding/hex: invalid byte: U+0078 'x'")
+}
+
+func TestVerify_bad_signature_invalid(t *testing.T) {
+	pk := suite.Point()
+
+	signed := SignedRequest{
+		Payload:   "yy",
+		Signature: "aef123",
+	}
+
+	err := signed.Verify(pk)
+	require.EqualError(t, err, "invalid signature: schnorr: signature of invalid length 3 instead of 64")
+}
+
+func TestVerify_empty_payload(t *testing.T) {
+	pk := suite.Point()
+
+	signed := SignedRequest{
+		Signature: "aef123",
+	}
+
+	err := signed.Verify(pk)
+	require.EqualError(t, err, "cannot verify empty payload")
+}
+
+func TestVerify_ok(t *testing.T) {
+	secret := suite.Scalar().Pick(suite.RandomStream())
+	pk := suite.Point().Mul(secret, nil)
+
+	payload := "xx"
+
+	hash := sha256.New()
+	hash.Write([]byte(payload))
+	md := hash.Sum(nil)
+
+	signature, err := schnorr.Sign(suite, secret, md)
+	require.NoError(t, err)
+
+	signed := SignedRequest{
+		Signature: hex.EncodeToString(signature),
+		Payload:   payload,
+	}
+
+	err = signed.Verify(pk)
+	require.NoError(t, err)
+}
+
+func TestGetAndVerify_verify_invalid_signature(t *testing.T) {
+	pk := suite.Point()
+
+	signed := SignedRequest{
+		Signature: "xx",
+	}
+
+	var req map[string]interface{}
+
+	err := signed.GetAndVerify(pk, &req)
+	require.EqualError(t, err, "failed to verify: cannot verify empty payload")
+}
+
+func TestGetAndVerify_wrong_message(t *testing.T) {
+	secret := suite.Scalar().Pick(suite.RandomStream())
+	pk := suite.Point().Mul(secret, nil)
+
+	msg := `{invalid json}`
+	payload := base64.URLEncoding.EncodeToString([]byte(msg))
+
+	hash := sha256.New()
+	hash.Write([]byte(payload))
+	md := hash.Sum(nil)
+
+	signature, err := schnorr.Sign(suite, secret, md)
+	require.NoError(t, err)
+
+	signed := SignedRequest{
+		Signature: hex.EncodeToString(signature),
+		Payload:   payload,
+	}
+
+	var req map[string]interface{}
+
+	err = signed.GetAndVerify(pk, &req)
+	require.EqualError(t, err, "failed to get message: failed to unmarshal "+
+		"json \"{invalid json}\" to *map[string]interface {}: invalid "+
+		"character 'i' looking for beginning of object key string")
+}
+
+func TestGetAndVerify_ok(t *testing.T) {
+	secret := suite.Scalar().Pick(suite.RandomStream())
+	pk := suite.Point().Mul(secret, nil)
+
+	msg := `{"Foo": "bar"}`
+	payload := base64.URLEncoding.EncodeToString([]byte(msg))
+
+	hash := sha256.New()
+	hash.Write([]byte(payload))
+	md := hash.Sum(nil)
+
+	signature, err := schnorr.Sign(suite, secret, md)
+	require.NoError(t, err)
+
+	signed := SignedRequest{
+		Signature: hex.EncodeToString(signature),
+		Payload:   payload,
+	}
+
+	type dummy struct {
+		Foo string
+	}
+
+	var req dummy
+
+	err = signed.GetAndVerify(pk, &req)
+	require.NoError(t, err)
+
+	expected := dummy{
+		Foo: "bar",
+	}
+
+	require.Equal(t, expected, req)
+}

--- a/services/dkg/pedersen/controller/action.go
+++ b/services/dkg/pedersen/controller/action.go
@@ -298,9 +298,23 @@ func (a *RegisterHandlersAction) Execute(ctx node.Context) error {
 
 	mngr := signed.NewManager(signer, &client)
 
+	proxykeyHex := ctx.Flags.String("proxykey")
+
+	proxykeyBuf, err := hex.DecodeString(proxykeyHex)
+	if err != nil {
+		return xerrors.Errorf("failed to decode proxykeyHex: %v", err)
+	}
+
+	proxykey := suite.Point()
+
+	err = proxykey.UnmarshalBinary(proxykeyBuf)
+	if err != nil {
+		return xerrors.Errorf("failed to unmarshal proxy key: %v", err)
+	}
+
 	router := mux.NewRouter()
 
-	ep := eproxy.NewDKG(mngr, dkg)
+	ep := eproxy.NewDKG(mngr, dkg, proxykey)
 
 	router.HandleFunc("/evoting/services/dkg/actors", ep.NewDKGActor).Methods("POST")
 	router.HandleFunc("/evoting/services/dkg/actors/{electionID}", ep.EditDKGActor).Methods("PUT")

--- a/services/dkg/pedersen/handler.go
+++ b/services/dkg/pedersen/handler.go
@@ -492,13 +492,11 @@ func (h *Handler) handleDecryptRequest(electionID string) error {
 		}
 
 		if accepted {
-			dela.Logger.Info().Msgf("our pubShares have been accepted on the chain, "+
-				"total # of submissions = %d, "+
-				"index: %v", len(election.PubsharesUnits.Pubshares), h.privShare.I)
+			dela.Logger.Info().Msgf("pubShares accepted on the chain (index: %d)", h.privShare.I)
 			return nil
 		}
 
-		dela.Logger.Info().Msgf("submission of pubShares denied: %v", msg)
+		dela.Logger.Info().Msgf("submission of pubShares denied: %s", msg)
 
 		cancel()
 	}

--- a/services/dkg/pedersen/types/http.go
+++ b/services/dkg/pedersen/types/http.go
@@ -1,6 +1,0 @@
-package types
-
-// UpdateDKG defines the input used to update dkg
-type UpdateDKG struct {
-	Action string
-}

--- a/start_test.sh
+++ b/start_test.sh
@@ -26,8 +26,10 @@ node1="tmux send-keys -t $s:0.%1"
 node2="tmux send-keys -t $s:0.%2"
 node3="tmux send-keys -t $s:0.%3"
 
-$node1 "./memcoin --config /tmp/node1 start --postinstall --promaddr :9100 --proxyaddr :9080 --proxykey=adbacd10fdb9822c71025d6d00092b8a4abb5ebcb673d28d863f7c7c5adaddf3 --port 2001" C-m
-$node2 "LLVL=info ./memcoin --config /tmp/node2 start --postinstall --promaddr :9101 --proxyaddr :9081 --proxykey=adbacd10fdb9822c71025d6d00092b8a4abb5ebcb673d28d863f7c7c5adaddf3 --port 2002" C-m
-$node3 "LLVL=info ./memcoin --config /tmp/node3 start --postinstall --promaddr :9102 --proxyaddr :9082 --proxykey=adbacd10fdb9822c71025d6d00092b8a4abb5ebcb673d28d863f7c7c5adaddf3 --port 2003" C-m
+pk=adbacd10fdb9822c71025d6d00092b8a4abb5ebcb673d28d863f7c7c5adaddf3
+
+$node1 "LLVL=info ./memcoin --config /tmp/node1 start --postinstall --promaddr :9100 --proxyaddr :9080 --proxykey $pk --port 2001" C-m
+$node2 "LLVL=info ./memcoin --config /tmp/node2 start --postinstall --promaddr :9101 --proxyaddr :9081 --proxykey $pk --port 2002" C-m
+$node3 "LLVL=info ./memcoin --config /tmp/node3 start --postinstall --promaddr :9102 --proxyaddr :9082 --proxykey $pk --port 2003" C-m
 
 tmux a

--- a/start_test.sh
+++ b/start_test.sh
@@ -26,8 +26,8 @@ node1="tmux send-keys -t $s:0.%1"
 node2="tmux send-keys -t $s:0.%2"
 node3="tmux send-keys -t $s:0.%3"
 
-$node1 "LLVL=info ./memcoin --config /tmp/node1 start --postinstall --promaddr :9100 --proxyaddr :9080 --port 2001" C-m
-$node2 "LLVL=info ./memcoin --config /tmp/node2 start --postinstall --promaddr :9101 --proxyaddr :9081 --port 2002" C-m
-$node3 "LLVL=info ./memcoin --config /tmp/node3 start --postinstall --promaddr :9102 --proxyaddr :9082 --port 2003" C-m
+$node1 "./memcoin --config /tmp/node1 start --postinstall --promaddr :9100 --proxyaddr :9080 --proxykey=adbacd10fdb9822c71025d6d00092b8a4abb5ebcb673d28d863f7c7c5adaddf3 --port 2001" C-m
+$node2 "LLVL=info ./memcoin --config /tmp/node2 start --postinstall --promaddr :9101 --proxyaddr :9081 --proxykey=adbacd10fdb9822c71025d6d00092b8a4abb5ebcb673d28d863f7c7c5adaddf3 --port 2002" C-m
+$node3 "LLVL=info ./memcoin --config /tmp/node3 start --postinstall --promaddr :9102 --proxyaddr :9082 --proxykey=adbacd10fdb9822c71025d6d00092b8a4abb5ebcb673d28d863f7c7c5adaddf3 --port 2003" C-m
 
 tmux a


### PR DESCRIPTION
- updates the scenario test to send signed queries
- updates the DKG proxy API to use a json type instead of plain text
- updates postinstall to include the frontend public key
- updates the scenario test to take the secret key as cli arg
- updates the proxies to accept and verify signed requests
- adds a generic function to send an http internal server error
- adds the signed request type
- updates start_test to include the proxykey

closes #78 