### PR TITLE
Adds better handling of errors

### DIFF
--- a/web/frontend/src/components/modal/Modal.tsx
+++ b/web/frontend/src/components/modal/Modal.tsx
@@ -44,7 +44,7 @@ const Modal = ({ showModal, setShowModal, textModal, buttonRightText }) => {
                     Notification
                   </Dialog.Title>
                   <div className="mt-2">
-                    <p className="text-sm text-gray-500">{textModal}</p>
+                    <p className="text-sm text-gray-500 break-words">{textModal}</p>
                   </div>
 
                   <div className="mt-4">

--- a/web/frontend/src/index.tsx
+++ b/web/frontend/src/index.tsx
@@ -71,17 +71,7 @@ export const FlashContext = createContext<FlashState>(undefined);
 const Loading: FC = () => <p>App is loading...</p>;
 
 const Failed: FC = ({ children }) => (
-  <div
-    className="
-    flex
-    items-center
-    justify-center
-    w-screen
-    h-screen
-    bg-gradient-to-r
-    from-red-600
-    to-red-700
-  ">
+  <div className="flex items-center justify-center w-screen h-screen bg-gradient-to-r from-red-600 to-red-700">
     <div className="px-5 py-3 bg-white rounded-md shadow-xl">
       <div className="flex flex-col items-center">
         <div className="p-4">

--- a/web/frontend/src/layout/NavBar.tsx
+++ b/web/frontend/src/layout/NavBar.tsx
@@ -21,7 +21,6 @@ const NavBar: FC = () => {
   const { t } = useTranslation();
 
   const authCtx = useContext(AuthContext);
-  const [loginError, setLoginError] = useState(null);
 
   const navigate = useNavigate();
 
@@ -241,7 +240,7 @@ const NavBar: FC = () => {
                         <button
                           id="login-button"
                           className="block px-4 py-2 text-sm text-gray-700'"
-                          onClick={() => handleLogin(loginError, setLoginError)}>
+                          onClick={() => handleLogin(fctx)}>
                           {t('login')}
                         </button>
                       </div>

--- a/web/frontend/src/mocks/handlers.ts
+++ b/web/frontend/src/mocks/handlers.ts
@@ -103,7 +103,7 @@ export const handlers = [
   }),
 
   rest.post(endpoints.newElection, (req, res, ctx) => {
-    const body: NewElectionBody = JSON.parse(req.body.toString());
+    const body = req.body as NewElectionBody;
 
     const createElection = (configuration: any) => {
       const newElectionID = uid();

--- a/web/frontend/src/pages/election/components/ElectionForm.tsx
+++ b/web/frontend/src/pages/election/components/ElectionForm.tsx
@@ -29,7 +29,6 @@ const ElectionForm: FC<ElectionFormProps> = ({ setShowModal, setTextModal }) => 
   // conf is the configuration object containing MainTitle and Scaffold which
   // contains an array of subject.
   const { t } = useTranslation();
-  const UserID = sessionStorage.getItem('id');
   const emptyConf: Configuration = emptyConfiguration();
   const [conf, setConf] = useState<Configuration>(emptyConf);
   const { MainTitle, Scaffold } = conf;
@@ -37,11 +36,11 @@ const ElectionForm: FC<ElectionFormProps> = ({ setShowModal, setTextModal }) => 
   async function createHandler() {
     const data = {
       Configuration: marshalConfig(conf),
-      UserID,
     };
     const req = {
       method: 'POST',
       body: JSON.stringify(data),
+      headers: { 'Content-Type': 'application/json' },
     };
 
     try {

--- a/web/frontend/src/pages/session/HandleLogin.tsx
+++ b/web/frontend/src/pages/session/HandleLogin.tsx
@@ -1,19 +1,22 @@
 import { ENDPOINT_GET_TEQ_KEY } from 'components/utils/Endpoints';
+import { FlashLevel, FlashState } from 'index';
 
 // The backend will provide the client the URL to make a Tequila authentication.
 // We therefore redirect to this address.
-const handleLogin = async (loginError: any, setLoginError: React.Dispatch<any>) => {
-  fetch(ENDPOINT_GET_TEQ_KEY)
-    .then((resp) => {
-      const jsonData = resp.json();
-      jsonData.then((result) => {
-        window.location = result.url;
-      });
-    })
-    .catch((error) => {
-      setLoginError(error);
-      console.log(error);
-    });
+const handleLogin = async (fctx: FlashState) => {
+  try {
+    const res = await fetch(ENDPOINT_GET_TEQ_KEY);
+
+    if (res.status !== 200) {
+      const txt = await res.text();
+      throw new Error(`unexpected status: ${res.status} - ${txt}`);
+    }
+
+    const json = await res.json();
+    window.location = json.url;
+  } catch (error) {
+    fctx.addMessage(error.toString(), FlashLevel.Error);
+  }
 };
 
 export default handleLogin;

--- a/web/frontend/src/pages/session/Login.tsx
+++ b/web/frontend/src/pages/session/Login.tsx
@@ -1,15 +1,17 @@
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 
 import { useLocation } from 'react-router-dom';
-import { ENDPOINT_GET_TEQ_KEY } from 'components/utils/Endpoints';
+import { FlashContext } from 'index';
+import handleLogin from './HandleLogin';
 
 const Login: FC = () => {
   const { t } = useTranslation();
-  const [loginError, setLoginError] = useState(null);
   const [content, setContent] = useState('');
   const location = useLocation();
+
+  const fctx = useContext(FlashContext);
 
   type LocationState = {
     from: Location;
@@ -22,24 +24,10 @@ const Login: FC = () => {
     }
   }, [location]);
 
-  const handleLogin = async () => {
-    fetch(ENDPOINT_GET_TEQ_KEY)
-      .then((resp) => {
-        const jsonData = resp.json();
-        jsonData.then((result) => {
-          window.location = result.url;
-        });
-      })
-      .catch((error) => {
-        setLoginError(error);
-        console.log(error);
-      });
-  };
-
   return (
     <div>
       <div className="flex py-8">{content}</div>
-      <button id="login-button" className="flex" onClick={handleLogin}>
+      <button id="login-button" className="flex" onClick={() => handleLogin(fctx)}>
         {t('login')}
       </button>
     </div>


### PR DESCRIPTION
Adds minor fixes to the frontend while working on the web-backend to support authenticated queries.

- updates the login handler to have one handler
- displays an error in case `get_personal_info` fails
- minor css fix on Modal
- fixes missing 'Content-Type' in request