### PR TITLE
Support lightweight tags

### DIFF
--- a/deb-package/build-deb.sh
+++ b/deb-package/build-deb.sh
@@ -38,7 +38,7 @@ mkdir -p deb/var/log/dedis/dvoting
 find deb ! -perm -a+r -exec chmod a+r {} \;
 
 # get version from git without v prefix
-GITVERSION=$(git describe --abbrev=0)
+GITVERSION=$(git describe --abbrev=0 --tags)
 VERSION=${GITVERSION:1}
 if [[ -z "${ITERATION}" ]]
 then


### PR DESCRIPTION
GitHub creates lightweight tags by default, and the `make deb` needs to support it.