### PR TITLE
Fix the polling when node is already setup

### DIFF
--- a/web/frontend/src/pages/election/components/utils/PollStatus.ts
+++ b/web/frontend/src/pages/election/components/utils/PollStatus.ts
@@ -56,7 +56,7 @@ const pollDKG = (
       }
 
       // TODO: define the error code for the case when a node is already setup
-      if (result.Error.Message.includes('already setup')) {
+      if (result.Error.Message.includes('setup() was already called, only one call is allowed')) {
         return resolve(result);
       }
 


### PR DESCRIPTION
While opening the issue #139  I realised that the error message used in the polling to avoid triggering an error when 
the user tries to setup a node that is already setup was not the correct one (order actually matters when calling `String.prototype.includes()` !)... 