### PR TITLE
Fix the ballot encoding

### DIFF
--- a/docs/ballot_encoding.md
+++ b/docs/ballot_encoding.md
@@ -46,14 +46,14 @@ A possible encoding of an answer would be (by string concatenation):
 "text:cd13:base64("Noémien"),base64("Pierluca")\n"
 ```
 
-## Size of the ballot
+## Size of the ballot 
 
 In order to maintain complete voter anonymity and untraceability of ballots throughout the 
 election process, it is important that all encrypted ballots have the same size. To this aim, 
-the election has an attribute called "BallotSize" (multiple of 29) which is the size 
+the election has an attribute called "BallotSize" which is the size 
 that all ballots should have before they're encrypted. Smaller ballots should therefore be 
 padded in order to reach this size. To denote the end of the ballot and the start of the padding,
-we use an empty line (\n\n). For a ballot size of 116, our ballot from the previous example 
+we use an empty line (\n\n). For a ballot size of 117, our ballot from the previous example 
 would then become:
 
 ```
@@ -63,5 +63,11 @@ would then become:
 
 "text:cd13:base64("Noémien"),base64("Pierluca")\n\n" +
 
-"ndtTx5uxmvnllH1T7NgLOREguUWbN"
+"ndtTx5uxmvnllH1T7NgLORuUWbN"
 ```
+
+## Chunks of ballot
+
+The encoded ballot must then be divided into chunks of 29 or less bytes since the maximum size supported by the kyber library for the encryption is of 29 bytes.
+
+For the previous example we would then have 5 chunks, the first 4 would contain 29 bytes, while the last chunk would contain a single byte.

--- a/web/frontend/src/pages/ballot/Show.tsx
+++ b/web/frontend/src/pages/ballot/Show.tsx
@@ -27,7 +27,7 @@ const Ballot: FC = () => {
 
   const { electionId } = useParams();
   const UserID = sessionStorage.getItem('id');
-  const { loading, configObj, electionID, status, pubKey, chunksPerBallot } =
+  const { loading, configObj, electionID, status, pubKey, ballotSize, chunksPerBallot } =
     useElection(electionId);
   const { configuration, answers, setAnswers } = useConfiguration(configObj);
 
@@ -75,7 +75,7 @@ const Ballot: FC = () => {
 
   const sendBallot = async () => {
     try {
-      const ballotChunks = voteEncode(answers, chunksPerBallot);
+      const ballotChunks = voteEncode(answers, ballotSize, chunksPerBallot);
       const EGPairs = Array<Buffer[]>();
       ballotChunks.forEach((chunk) =>
         EGPairs.push(encryptVote(chunk, Buffer.from(hexToBytes(pubKey).buffer), edCurve))


### PR DESCRIPTION
Fix the ballot encoding:  padding is added until the size of the encoded ballot is equal to the `BallotSize`.