### PR TITLE
Change back question ID length to 8 bytes

### DIFF
--- a/web/frontend/src/types/getObjectType.ts
+++ b/web/frontend/src/types/getObjectType.ts
@@ -2,7 +2,7 @@ import ShortUniqueId from 'short-unique-id';
 import * as types from './configuration';
 import { ID, RANK, SELECT, SUBJECT, TEXT } from './configuration';
 
-const uid: Function = new ShortUniqueId({ length: 3 });
+const uid: Function = new ShortUniqueId({ length: 8 });
 
 const emptyConfiguration = (): types.Configuration => {
   return { MainTitle: '', Scaffold: [] };


### PR DESCRIPTION
Change the ID length of questions during Election create back to 8 bytes.