### PR TITLE
Fix web backend to redirect DKG setup requests

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -329,7 +329,8 @@ Return:
 
 ```json
 {
-  "ElectionID": "<hex encoded>"
+  "ElectionID": "<hex encoded>",
+  "Proxy:": ""
 }
 ```
 
@@ -351,7 +352,8 @@ Return:
 
 ```json
 {
-  "Action": "setup"
+  "Action": "setup",
+  "Proxy:": ""
 }
 ```
 

--- a/web/backend/src/Server.ts
+++ b/web/backend/src/Server.ts
@@ -408,7 +408,7 @@ function sendToDela(dataStr: string, req: express.Request, res: express.Response
   }
 
   // in case this is a DKG setup request, we must update the payload.
-  const dkgSetupRegex = /\/evoting\/services\/dkg\/actors\//;
+  const dkgSetupRegex = /\/evoting\/services\/dkg\/actors\/.*$/;
   if (uri.match(dkgSetupRegex)) {
     const dataStr2 = JSON.stringify({ Action: req.body.Action });
     payload = getPayload(dataStr2);

--- a/web/backend/src/Server.ts
+++ b/web/backend/src/Server.ts
@@ -400,13 +400,6 @@ function sendToDela(dataStr: string, req: express.Request, res: express.Response
   // we strip the `/api` part: /api/election/xxx => /election/xxx
   let uri = process.env.DELA_NODE_URL + req.baseUrl.slice(4);
 
-  // in case this is a DKG setup request, we must update the payload.
-  const regex = /\/evoting\/services\/dkg\/actors/;
-  if (uri.match(regex)) {
-    const dataStr2 = JSON.stringify({ Action: req.body.Action });
-    payload = getPayload(dataStr2);
-  }
-
   // in case this is a DKG init request, we must also update the payload.
   const dkgInitRegex = /\/evoting\/services\/dkg\/actors$/;
   if (uri.match(dkgInitRegex)) {
@@ -414,8 +407,15 @@ function sendToDela(dataStr: string, req: express.Request, res: express.Response
     payload = getPayload(dataStr2);
   }
 
+  // in case this is a DKG setup request, we must update the payload.
+  const dkgSetupRegex = /\/evoting\/services\/dkg\/actors\//;
+  if (uri.match(dkgSetupRegex)) {
+    const dataStr2 = JSON.stringify({ Action: req.body.Action });
+    payload = getPayload(dataStr2);
+  }
+
   // in case this is a DKG init or setup request, we must extract the proxy addr
-  if (uri.match(regex)) {
+  if (uri.match(dkgInitRegex) || uri.match(dkgSetupRegex)) {
     const proxy = req.body.Proxy;
 
     if (proxy === undefined) {

--- a/web/backend/src/Server.ts
+++ b/web/backend/src/Server.ts
@@ -400,14 +400,24 @@ function sendToDela(dataStr: string, req: express.Request, res: express.Response
   // we strip the `/api` part: /api/election/xxx => /election/xxx
   let uri = process.env.DELA_NODE_URL + req.baseUrl.slice(4);
 
-  // in case this is a DKG  init request, we must extract the proxy addr and
-  // update the payload.
-  const regex = /\/evoting\/services\/dkg\/actors$/;
+  // in case this is a DKG setup request, we must update the payload.
+  const regex = /\/evoting\/services\/dkg\/actors/;
   if (uri.match(regex)) {
+    const dataStr2 = JSON.stringify({ Action: req.body.Action });
+    payload = getPayload(dataStr2);
+  }
+
+  // in case this is a DKG init request, we must also update the payload.
+  const dkgInitRegex = /\/evoting\/services\/dkg\/actors$/;
+  if (uri.match(dkgInitRegex)) {
     const dataStr2 = JSON.stringify({ ElectionID: req.body.ElectionID });
     payload = getPayload(dataStr2);
+  }
 
+  // in case this is a DKG init or setup request, we must extract the proxy addr
+  if (uri.match(regex)) {
     const proxy = req.body.Proxy;
+
     if (proxy === undefined) {
       res.status(400).send('proxy undefined in body');
       return;


### PR DESCRIPTION
I am absolutely not sure if this is correctly written !
But currently DKG setup requests are not redirected, they use the default proxy, the idea is to redirect them to the correct proxy (the one provided in the input json). 
As the `regex` used to check if it's an initialisation request does not match the setup i.e `const regex = /\/evoting\/services\/dkg\/actors$/` does not match with the setup endpoint: `/api/evoting/services/dkg/actors/${ElectionID}`