### PR TITLE
Fix the decryption so that it uses the default proxy

### DIFF
--- a/web/backend/src/Server.ts
+++ b/web/backend/src/Server.ts
@@ -399,12 +399,15 @@ function sendToDela(dataStr: string, req: express.Request, res: express.Response
 
   // we strip the `/api` part: /api/election/xxx => /election/xxx
   let uri = process.env.DELA_NODE_URL + req.baseUrl.slice(4);
-
+  // boolean to check
+  let redirectToDefaultProxy = true;
   // in case this is a DKG init request, we must also update the payload.
+
   const dkgInitRegex = /\/evoting\/services\/dkg\/actors$/;
   if (uri.match(dkgInitRegex)) {
     const dataStr2 = JSON.stringify({ ElectionID: req.body.ElectionID });
     payload = getPayload(dataStr2);
+    redirectToDefaultProxy = false;
   }
 
   // in case this is a DKG setup request, we must update the payload.
@@ -412,10 +415,16 @@ function sendToDela(dataStr: string, req: express.Request, res: express.Response
   if (uri.match(dkgSetupRegex)) {
     const dataStr2 = JSON.stringify({ Action: req.body.Action });
     payload = getPayload(dataStr2);
+
+    // If setup don't redirect to default proxy, if 'computePubshares' then keep
+    // default proxy
+    if (req.body.Action === 'setup') {
+      redirectToDefaultProxy = false;
+    }
   }
 
   // in case this is a DKG init or setup request, we must extract the proxy addr
-  if (uri.match(dkgInitRegex) || uri.match(dkgSetupRegex)) {
+  if (!redirectToDefaultProxy) {
     const proxy = req.body.Proxy;
 
     if (proxy === undefined) {


### PR DESCRIPTION
The computePubShares and the setup of the nodes use the same endpoints but the computePubShares does not need to be redirected to a proxy address explicitly (it can use the default)