### PR TITLE
Add Contributors to the About page

### DIFF
--- a/web/backend/tsconfig.json
+++ b/web/backend/tsconfig.json
@@ -36,7 +36,9 @@
     "dbUtils.js"
   ],
   "typedocOptions": {
-    "entryPoints": ["src/Server.ts"],
+    "entryPoints": [
+      "src/Server.ts"
+    ],
     "out": "tsdocs"
   }
 }

--- a/web/frontend/src/language/en.json
+++ b/web/frontend/src/language/en.json
@@ -217,6 +217,7 @@
     "fr": "🇫🇷 French",
     "de": "🇩🇪 German",
     "save": "Save",
+    "contributors": "Our contributors",
     "nodeSetup": "Node setup",
     "inputNodeSetup": "Choose which node to start the setup on:",
     "inputProxyAddressError": "Error: the address of a proxy cannot be empty.",

--- a/web/frontend/src/pages/About.tsx
+++ b/web/frontend/src/pages/About.tsx
@@ -68,6 +68,15 @@ const About: FC = () => {
               <img src={dVotingSystem} alt="" />
             </div>
           </div>
+          <div className="text-base max-w-prose mx-auto lg:max-w-none">
+            <div className="text-4xl mt-10 leading-8 font-extrabold tracking-tight text-gray-900 max-w-none lg:mx-auto">
+              <p>{t('contributors')}</p>
+            </div>
+            <p className="relative z-10 mt-2 font-medium prose prose-indigo text-gray-500">
+              Anas Ibrahim, Vincent Parodi, Sarah Antille, Auguste Baum, Emilien Duc, Ambroise
+              Borbely, Guanyu Zhand, Igowa Giovanni, Badr Larhdir, Capucine Berger
+            </p>
+          </div>
         </div>
       </div>
     </div>

--- a/web/frontend/src/pages/About.tsx
+++ b/web/frontend/src/pages/About.tsx
@@ -16,11 +16,11 @@ const About: FC = () => {
           </p>
         </div>
         <div className="relative z-10 text-base max-w-prose mx-auto lg:max-w-5xl lg:mx-0 lg:pr-72">
-          <p className="text-lg text-gray-500">{t('about0')}</p>
+          <p className="text-lg text-justify text-gray-500">{t('about0')}</p>
         </div>
         <div className="lg:grid lg:grid-cols-2 lg:gap-8 lg:items-start">
           <div className="relative z-10">
-            <div className="prose prose-indigo text-gray-500 mx-auto lg:max-w-none">
+            <div className="prose prose-indigo text-justify text-gray-500 mx-auto lg:max-w-none">
               <p>{t('about1')}</p>
               <p>{t('about2')}</p>
               <p>{t('about3')}</p>
@@ -72,9 +72,11 @@ const About: FC = () => {
             <div className="text-4xl mt-10 leading-8 font-extrabold tracking-tight text-gray-900 max-w-none lg:mx-auto">
               <p>{t('contributors')}</p>
             </div>
-            <p className="relative z-10 mt-2 font-medium prose prose-indigo text-gray-500">
+            <p className="relative text-justify z-10 mt-2 font-medium prose prose-indigo text-gray-500">
               Anas Ibrahim, Vincent Parodi, Sarah Antille, Auguste Baum, Emilien Duc, Ambroise
-              Borbely, Guanyu Zhand, Igowa Giovanni, Badr Larhdir, Capucine Berger
+              Borbely, Guanyu Zhand, Igowa Giovanni, Badr Larhdir, Capucine Berger, Albert
+              Troussard, Mohamed Amine Benaziz, Chen Chang Lew, Ahmed Kamal Elalamy, Ghita
+              Tagemouati, Khadija Tagemouati.
             </p>
           </div>
         </div>

--- a/web/frontend/src/pages/About.tsx
+++ b/web/frontend/src/pages/About.tsx
@@ -72,7 +72,7 @@ const About: FC = () => {
             <div className="text-4xl mt-10 leading-8 font-extrabold tracking-tight text-gray-900 max-w-none lg:mx-auto">
               <p>{t('contributors')}</p>
             </div>
-            <p className="relative text-justify z-10 mt-2 font-medium prose prose-indigo text-gray-500">
+            <p className="text-justify mt-2 font-medium prose prose-indigo text-gray-500">
               Anas Ibrahim, Vincent Parodi, Sarah Antille, Auguste Baum, Emilien Duc, Ambroise
               Borbely, Guanyu Zhand, Igowa Giovanni, Badr Larhdir, Capucine Berger, Albert
               Troussard, Mohamed Amine Benaziz, Chen Chang Lew, Ahmed Kamal Elalamy, Ghita


### PR DESCRIPTION
This patch will add a section at the end of the about page containing all the current contributors. I also added a "contributors" field for later i18n and translation.