### PR TITLE
Add security txt to the system

### DIFF
--- a/web/frontend/public/.well-known/security.txt
+++ b/web/frontend/public/.well-known/security.txt
@@ -1,0 +1,3 @@
+Contact: mailto:dedis-security@epfl.ch
+Expires: 2023-12-31T22:59:00.000Z
+Preferred-Languages: en, fr


### PR DESCRIPTION
Implement security.txt in d-voting.
“When security risks in web services are discovered by independent security researchers who understand the severity of the risk, they often lack the channels to disclose them properly. As a result, security issues may be left unreported. security.txt defines a standard to help organizations define the process for security researchers to disclose security vulnerabilities securely.”

security txt website: https://securitytxt.org/
security txt github: https://github.com/securitytxt/security-txt
