### PR TITLE
refactor: organise permissions into an object

### DIFF
--- a/web/backend/src/Server.ts
+++ b/web/backend/src/Server.ts
@@ -267,7 +267,7 @@ app.get('/api/user_rights', (req, res) => {
 // This call (only for admins) allow an admin to add a role to a voter.
 app.post('/api/add_role', (req, res, next) => {
   if (!isAuthorized(req.session.userid, PERMISSIONS.SUBJECTS.ROLES, PERMISSIONS.ACTIONS.ADD)) {
-    res.status(400).send({ error: 'user not logged-in or does not have enough permissions' });
+    res.status(400).send('Unauthorized - only admins allowed');
     return;
   }
 


### PR DESCRIPTION
I believe this new structure makes it a lot easier to read the permissions. 

when you read `PERMISSIONS.ACTIONS.LIST` this probably matches more how our brain would prefer the information to be presented.