### PR TITLE
Consistent sleeps throughout all tests

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -209,6 +209,8 @@ func getIntegrationTestCrash(numNodes, numVotes, failingNodes int) func(*testing
 		formID, err := createForm(m, "Three votes form", adminID)
 		require.NoError(t, err)
 
+		time.Sleep(time.Second * 1)
+
 		// ##### SETUP DKG #####
 		actor, err := initDkg(nodes, formID, m.m)
 		require.NoError(t, err)


### PR DESCRIPTION
Adds a simple sleep after form creation in 1 test where it was missing and usually fails the pipeline.